### PR TITLE
Add mongoimport task

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ We will be doing analysis on CU-Boulder's public FCQ dataset.  The data is in .c
 
 # Setup
 
-	npm install
+1. Install the packages: `npm install`
+2. Import the data: `gulp import`
 
 # Run
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,8 +1,11 @@
-var gulp = require('gulp'),
-    csv2 = require('csv2'),
+'use strict';
+
+var gulp     = require('gulp'),
+    csv2     = require('csv2'),
     through2 = require('through2'),
-    _ = require('lodash'),
-    rename = require("gulp-rename")
+    _        = require('lodash'),
+    rename   = require('gulp-rename'),
+    process  = require('child_process');
 
 gulp.task('csv2json', function() {
 
@@ -11,9 +14,9 @@ gulp.task('csv2json', function() {
 
     return gulp.src(src, {
             buffer: false   // assuming the input data file is large, open it as a stream
-        })        
+        })
         .pipe(through2.obj(function(file, enc, callback) {
-                    
+
             var header
             // modify the file contents to be a stream of JSON strings
             file.contents = file.contents
@@ -41,4 +44,27 @@ gulp.task('csv2json', function() {
             path.extname = ".json"
         }))
         .pipe(gulp.dest(dest))
-})
+});
+
+gulp.task('import', function() {
+    var database = 'sikuli';
+    var collection = 'fcq';
+
+    var args = [
+        '--type', 'csv',
+        '--headerline',
+        '-d', database,
+        '-c', collection,
+        '--file', 'data/fcq.csv'
+    ]
+
+    var mongoimport = process.spawn('mongoimport', args);
+
+    mongoimport.stdout.on('data', function (data) {
+        console.log(data.toString());
+    });
+
+    mongoimport.stderr.on('data', function (data) {
+        console.error(data.toString());
+    });
+});


### PR DESCRIPTION
This adds a task to import the data into Mongo: `$ gulp import`

I am using the database name 'sikuli' and the collection name 'fcq' as the defaults here. If anyone objects, we can either change it or make it configurable for the user.
