### PR TITLE
Sanitize percentages in dataset

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,7 +56,7 @@ gulp.task('import', function() {
         '-d', database,
         '-c', collection,
         '--file', 'data/fcqFiltered.json'
-    ]
+    ];
 
     var mongoimport = process.spawn('mongoimport', args);
 
@@ -89,7 +89,7 @@ gulp.task('sanitize', function() {
 
         // Coerce percentage to float
         var coerceToFloat = function(val) {
-            return val.match(/[0-9]+/) / 100
+            return val.match(/[0-9]+/) / 100;
         };
 
         // Coerce when we have a percentage, otherwise do nothing
@@ -105,14 +105,14 @@ gulp.task('sanitize', function() {
 
     // Since Mongo is not very friendly with JSON arrays, we newline each entry
     var mongoifyOutputToFile = function(collection) {
-        var outputFile = 'data/fcqFiltered.json'
+        var outputFile = 'data/fcqFiltered.json';
         var appendFile = _.partial(fs.appendFileSync, outputFile);
 
         _.each(collection, function(val) {
             appendFile(JSON.stringify(val) + "\n");
         });
 
-        console.log('Successfully wrote to file.')
+        console.log('Successfully wrote to file.');
 
         return;
     };


### PR DESCRIPTION
Here is a Gulp helper to sanitize the data. The percentage data with the FCQs was in a whacky format. This cleans that.

I plan on ripping all of this logic out to make it applicable to any JSON dataset (possibly it's own CL tool). The API will work such that you can specify (with code) how to process each data point. Something like:

``` js
{
  "PCT_A" : function(val) { return parseIt(val); // some logic to clean the percentage },
  "NAME" : function(val) { return val.uppercase(); }
}
```

Something along those lines.
