### PR TITLE
Promisify mongodb

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,7 @@
 {
-    "asi": true,
-    "node": true
+  "asi": true,
+  "node": true,
+  "globals": {
+    "Promise": true
+  }
 }

--- a/lib/diff/data.js
+++ b/lib/diff/data.js
@@ -3,10 +3,13 @@ var fs = require('fs')
 var csv = require('csv');
 var _ = require('lodash');
 var mongodb = require('mongodb');
-var mongoClient = require('mongodb').MongoClient;
+var Promise = require('bluebird');
 
 var jsonPath = './data/fcq.json'
 var csvPath = './data/fcq.csv'
+
+Promise.promisifyAll(mongodb);
+var MongoClient = mongodb.MongoClient;
 
 var plugin = function(diff) {
 
@@ -19,16 +22,18 @@ var plugin = function(diff) {
     })
 
     diff.dataProvider('$mongodb', function(callback) {
-            mongoClient.connect("mongodb://localhost:27017/sikuli", function (err, db) {
-                if(err){
-                    debug(err)
-                    db.close();
-                }
-                debug("Connected to sikuli  database")
-                callback(null,db);
-             });
-        })
-}
+        MongoClient.connectAsync('mongodb://localhost:27017/sikuli')
+            .then(function(db) {
+                callback(null, db);
+            })
+            .catch(function(err) {
+                debug(err);
+            })
+            .disposer(function(db) {
+                db.close();
+            });
+    })
+};
 
 module.exports = plugin
 
@@ -45,7 +50,7 @@ function readJSON(path, callback) {
             callback(Error)
 
         var json = []
-        
+
         data.split('\n')
             .forEach(function(line) {
                 try {
@@ -56,7 +61,7 @@ function readJSON(path, callback) {
             })
 
         debug('read %d records', json.length)
-        callback(null, json) 
+        callback(null, json)
     })
 }
 

--- a/lib/diff/questions/ianks.js
+++ b/lib/diff/questions/ianks.js
@@ -12,7 +12,7 @@ var plugin = function(diff) {
                   ['$mongodb'], function($mongodb, callback) {
         var fcq = $mongodb.collection('fcq');
 
-        fcq.aggregate([
+        fcq.aggregateAsync([
             {
                 $group : {
                     _id : {
@@ -29,9 +29,14 @@ var plugin = function(diff) {
             {
                 $limit : 10
             }
-        ], function(err, result){
+        ]).then(function(result){
             callback(null, result);
+
+            // FIXME: This resource should be managed using disposer, but the
+            // current implementation is hindering that.
             $mongodb.close();
+        }).catch(function(err) {
+            debug(err);
         });
     });
 
@@ -40,7 +45,7 @@ var plugin = function(diff) {
                   ['$mongodb'], function($mongodb, callback) {
         var fcq = $mongodb.collection('fcq');
 
-        fcq.aggregate([
+        fcq.aggregateAsync([
             {
                 $match : { "Subject" : "CSCI" }
             },
@@ -61,9 +66,11 @@ var plugin = function(diff) {
             {
                 $sort : { _id : -1 }
             }
-        ], function(err, result){
+        ]).then(function(result){
             callback(null, result);
             $mongodb.close();
+        }).catch(function(err) {
+            debug(err);
         });
     });
 
@@ -72,7 +79,7 @@ var plugin = function(diff) {
                   ['$mongodb'], function($mongodb, callback) {
         var fcq = $mongodb.collection('fcq');
 
-        fcq.aggregate([
+        fcq.aggregateAsync([
             {
                 $match : {
                     "YearTerm" : { $regex: new RegExp("(2012|2013)") }
@@ -105,7 +112,7 @@ var plugin = function(diff) {
                     }
                 }
             }
-        ], function(err, result){
+        ]).then(function(result) {
             var cleaned = _.select(result, function(object){
                 var realInstructorRating = _.every(object.years, function(n) {
                     return n.avgInstructor > 0;
@@ -127,6 +134,8 @@ var plugin = function(diff) {
 
             callback(null, sorted);
             $mongodb.close();
+        }).catch(function(err) {
+            debug(err);
         });
     });
 
@@ -135,7 +144,7 @@ var plugin = function(diff) {
                   ['$mongodb'], function($mongodb, callback) {
         var fcq = $mongodb.collection('fcq');
 
-        fcq.aggregate([
+        fcq.aggregateAsync([
             {
                 $project : {
                     "Subject" : "$Subject",
@@ -168,9 +177,11 @@ var plugin = function(diff) {
                     }
                 }
             }
-        ], function(err, result){
+        ]).then(function(result){
             callback(null, result);
             $mongodb.close();
+        }).catch(function(err) {
+            debug(err);
         });
     });
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "app.js",
   "dependencies": {
     "async": "^0.9.0",
+    "bluebird": "^2.8.2",
     "chalk": "^0.5.1",
     "csv": "^0.4.1",
     "csv-parser": "^1.5.0",


### PR DESCRIPTION
This wraps Mongo in with [bluebird](https://github.com/petkaantonov/bluebird/blob/master/API.md) promises. I find promises to be a good abstraction/way to avoid callback abyss. 

I'm still learning a lot about the bluebird API, so there is definitely room for improvement. Firstly, we prob. need refactor in some places so we can manage closing the DB using the [disposer](https://github.com/petkaantonov/bluebird/blob/master/API.md#disposerfunction-disposer---disposer) function. 

Also, @doubleshow, am I right to assume that a new Mongo connection is instantiated for each question? I might have a look at opening up a singleton connection, which will a) minimize number of connections and b) make managing the mongo resource a bit simpler (you won't have to close it on every query, etc.)
